### PR TITLE
Throw exception if applicationstorage is accessed too early

### DIFF
--- a/src/lime/system/System.hx
+++ b/src/lime/system/System.hx
@@ -360,17 +360,16 @@ class System
 				var company = "MyCompany";
 				var file = "MyApplication";
 
-				if (Application.current != null)
-				{
-					if (Application.current.meta.exists("company"))
-					{
-						company = Application.current.meta.get("company");
-					}
+				if (Application.current == null) throw "Cannot access ApplicationStorage before Application is available";
 
-					if (Application.current.meta.exists("file"))
-					{
-						file = Application.current.meta.get("file");
-					}
+				if (Application.current.meta.exists("company"))
+				{
+					company = Application.current.meta.get("company");
+				}
+
+				if (Application.current.meta.exists("file"))
+				{
+					file = Application.current.meta.get("file");
 				}
 
 				#if hl


### PR DESCRIPTION
# Context

Per suggestion from @stnguyen, we'll throw exception to fail early in the `lime` repo, so that we don't misuse `lime.system.System.applicationStorageDirectory`

# Changes

- Throw exception in `System.hx::__getDirectory` when `Application.current == null`

# Test cases

## Developer test

- Tested with old code in 1.48.03 the game crashes on launch with the right exception message
- Tested with new code in master the game runs normally with correct storagePath

## QA Test

- Regression test to make sure the game can progress normally and no progress is lost